### PR TITLE
report: Use a better Excel icon

### DIFF
--- a/templates/components/report.pug
+++ b/templates/components/report.pug
@@ -50,7 +50,7 @@ md-content(flex, layout-padding)
 			md-divider
 			md-card-actions(layout="row" layout-align="end center")
 				md-button.md-icon-button(ng-click="downloadAttendeesCsv()")
-					md-icon(md-svg-icon="file-excel-box")
+					md-icon(md-svg-icon="file-excel")
 				md-button.md-icon-button(ng-click="downloadAttendeesJson()")
 					md-icon(md-svg-icon="json")
 				span(flex)


### PR DESCRIPTION
This makes the Excel icon on the CSV download button actually look like it'll do something other than delete everything.
